### PR TITLE
sort files by build id numerically

### DIFF
--- a/src/lambdacd_artifacts/core.clj
+++ b/src/lambdacd_artifacts/core.clj
@@ -4,12 +4,14 @@
             [ring.util.response :as response]
             [compojure.route :refer :all]
             [compojure.core :refer :all])
-  (:import (java.io File)
-           (java.nio.file Paths)))
+  (:import (java.nio.file Paths)))
+
+(defn- file-to-build-id [f]
+  (read-string (.getName f)))
 
 (defn- find-latest-artifact [home-dir step-id path]
   (let [home-file (io/file home-dir)
-        build-directories (.listFiles home-file)
+        build-directories (sort-by file-to-build-id (.listFiles home-file))
         latest-build-directory (last (filter #(.exists (io/file % step-id path)) build-directories))]
     (io/file latest-build-directory step-id)))
 

--- a/test/lambdacd_artifacts/core_test.clj
+++ b/test/lambdacd_artifacts/core_test.clj
@@ -12,11 +12,12 @@
             (spit (file-with-parents home-dir "2" "some-step-id" "some-artifact.txt") "uber content")
             (spit (file-with-parents home-dir "3" "some-step-id" "some-other-artifact.txt") "not so uber content")
             (spit (file-with-parents home-dir "4" "some-other-step-id" "some-artifact.txt") "what do you care?")
+            (spit (file-with-parents home-dir "10" "some-step-id" "some-artifact.txt") "uber content")
 
             (testing "that explicit build-number selection works"
               (is (= (io/file home-dir "1" "some-step-id") (root-path home-dir 1 "some-step-id" "some-artifact.txt"))))
             (testing "that 'latest' picks the latest available artifact"
-              (is (= (io/file home-dir "2" "some-step-id") (root-path home-dir "latest" "some-step-id" "some-artifact.txt"))))))
+              (is (= (io/file home-dir "10" "some-step-id") (root-path home-dir "latest" "some-step-id" "some-artifact.txt"))))))
 
 (defn map-containing [expected m]
   (and (every? (set (keys m)) (keys expected))


### PR DESCRIPTION
picking just the last file results in broken "latest" links for instances with >9 builds
